### PR TITLE
Hotfix of Gulp Dev task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,7 +149,7 @@ gulp.task('serve', function() {
  * @name dev
  * @desc The develop task - serve the app and watch for file updates
  */
-gulp.task('dev', ['serve', 'watch']);
+gulp.task('dev', ['build', 'serve', 'watch']);
 
 
 


### PR DESCRIPTION
Added build task before serve and watch inside dev task. Fixes error where no server found on first run of dev.
